### PR TITLE
feat: added core logic to extend initialized

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 Fluid Privacy SA
+Copyright (c) 2025 Fluid Privacy SA
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from './generateStealthAddresses';
 export * from './generateStealthPrivateKey';
 export * from './predictStealthSafeAddress';
 export * from './utils/generateFluidkeyMessage';
+export { InitializerExtraFields } from './predictStealthSafeAddressTypes';

--- a/src/predictStealthSafeAddress.ts
+++ b/src/predictStealthSafeAddress.ts
@@ -15,7 +15,7 @@ import {
   toBytes,
 } from 'viem';
 import * as chains from 'viem/chains';
-import { SafeVersion } from './predictStealthSafeAddressTypes';
+import { InitializerExtraFields, SafeVersion } from './predictStealthSafeAddressTypes';
 
 /**
  * Using Viem transaction simulation, predict a new Safe address using the parameters passed in input.
@@ -26,6 +26,7 @@ import { SafeVersion } from './predictStealthSafeAddressTypes';
  * @param chainId {number} (optional) the chainId of the network where the Safe will be deployed
  * @param transport (optional) a custom viem transport to use for the simulation
  * @param safeVersion {SafeVersion} the Safe version to use
+ * @param initializerExtraFields {InitializerExtraFields | undefined} (optional) the extra fields that can be optionally set in the initializer
  * @return Promise<{ stealthSafeAddress }> the predicted Safe address (not deployed)
  */
 export async function predictStealthSafeAddressWithClient({
@@ -35,6 +36,7 @@ export async function predictStealthSafeAddressWithClient({
   transport,
   useDefaultAddress,
   safeVersion,
+  initializerExtraFields,
 }: {
   threshold: number;
   stealthAddresses: `0x${string}`[];
@@ -42,6 +44,7 @@ export async function predictStealthSafeAddressWithClient({
   transport?: any;
   useDefaultAddress?: boolean;
   safeVersion: SafeVersion;
+  initializerExtraFields?: InitializerExtraFields;
 }): Promise<{ stealthSafeAddress: `0x${string}` }> {
 
   // if useDefaultAddress is false, chainId is required
@@ -60,6 +63,7 @@ export async function predictStealthSafeAddressWithClient({
     stealthAddresses,
     useDefaultAddress,
     safeVersion,
+    initializerExtraFields,
   });
 
   const safeSingletonAddress = useDefaultAddress ? safeSingleton.defaultAddress : safeSingleton.networkAddresses[chainId.toString()];
@@ -108,6 +112,7 @@ export async function predictStealthSafeAddressWithClient({
  * @param stealthAddresses {string[]} the stealth addresses controlling the Safe
  * @param chainId {number} (optional) the chainId of the network where the Safe will be deployed
  * @param useDefaultAddress {boolean} (optional) if true, the Safe default address will be used - see DefaultAddress inside https://github.com/safe-global/safe-deployments
+ * @param initializerExtraFields {InitializerExtraFields | undefined} (optional) the extra fields that can be optionally set in the initializer
  * @return Promise<{ stealthSafeAddress }> the predicted Safe address (not deployed)
  */
 export function predictStealthSafeAddressWithBytecode({
@@ -117,6 +122,7 @@ export function predictStealthSafeAddressWithBytecode({
   stealthAddresses,
   useDefaultAddress,
   safeVersion,
+  initializerExtraFields,
 }: {
   safeProxyBytecode: `0x${string}`;
   threshold: number;
@@ -124,6 +130,7 @@ export function predictStealthSafeAddressWithBytecode({
   chainId?: number;
   useDefaultAddress?: boolean;
   safeVersion: SafeVersion;
+  initializerExtraFields?: InitializerExtraFields;
 }): { stealthSafeAddress: `0x${string}` } {
   // if useDefaultAddress is false, chainId is required
   if (!useDefaultAddress) {
@@ -141,6 +148,7 @@ export function predictStealthSafeAddressWithBytecode({
     stealthAddresses,
     useDefaultAddress,
     safeVersion,
+    initializerExtraFields,
   });
 
   const safeSingletonAddress = useDefaultAddress ? safeSingleton.defaultAddress : safeSingleton.networkAddresses[chainId.toString()];
@@ -177,6 +185,7 @@ export function predictStealthSafeAddressWithBytecode({
  * @param chainId {number} (optional) the chainId of the network where the Safe will be deployed
  * @param useDefaultAddress {boolean} (optional) if true, the Safe default address will be used - see DefaultAddress inside https://github.com/safe-global/safe-deployments
  * @param safeVersion {SafeVersion} the Safe version to use
+ * @param initializerExtraFields {InitializerExtraFields | undefined} (optional) the extra fields that can be optionally set in the initializer
  */
 function getSafeInitializerData ({
   chainId,
@@ -184,12 +193,14 @@ function getSafeInitializerData ({
   stealthAddresses,
   useDefaultAddress,
   safeVersion,
+  initializerExtraFields,
 }: {
   threshold: number;
   stealthAddresses: `0x${string}`[];
   chainId: number;
   useDefaultAddress?: boolean;
   safeVersion: SafeVersion;
+  initializerExtraFields?: InitializerExtraFields;
 }): {
     initializer: `0x${string}`;
     proxyFactory: SingletonDeployment;
@@ -229,12 +240,12 @@ function getSafeInitializerData ({
     args: [
       stealthAddresses,
       threshold,
-      ZERO_ADDRESS,
-      '0x',
-      fallbackHandlerAddress,
-      ZERO_ADDRESS,
-      0,
-      ZERO_ADDRESS,
+      !!initializerExtraFields?.to ? initializerExtraFields.to : ZERO_ADDRESS,
+      !!initializerExtraFields?.data ? initializerExtraFields.data : '0x',
+      !!initializerExtraFields?.fallbackHandler ? initializerExtraFields.fallbackHandler : fallbackHandlerAddress,
+      !!initializerExtraFields?.paymentToken ? initializerExtraFields.paymentToken : ZERO_ADDRESS,
+      !!initializerExtraFields?.payment ? initializerExtraFields.payment : '0',
+      !!initializerExtraFields?.paymentReceiver ? initializerExtraFields.paymentReceiver : ZERO_ADDRESS,
     ],
   });
 

--- a/src/predictStealthSafeAddressTypes.ts
+++ b/src/predictStealthSafeAddressTypes.ts
@@ -1,1 +1,16 @@
 export type SafeVersion = '1.4.1' | '1.3.0' | '1.2.0' | '1.1.1' | '1.0.0';
+
+/**
+ * Extra options that can be set within the Initializer when deploying a Stealth Safe.
+ * For references on their values see how params are used during the setup
+ * ( https://github.com/safe-global/safe-smart-account/blob/77bab0d37b78c26482f94662344c9af0994253f7/contracts/Safe.sol#L84 )
+ */
+export type InitializerExtraFields = {
+  to?: `0x${string}`;
+  data?: `0x${string}`;
+  fallbackHandler?: `0x${string}`;
+  paymentToken?: `0x${string}`;
+  /** The payment amount. Set as string to avoid losing precision on large numbers. */
+  payment?: string;
+  paymentReceiver?: `0x${string}`;
+}

--- a/test/predictStealthSafeAddress.test.ts
+++ b/test/predictStealthSafeAddress.test.ts
@@ -1,5 +1,6 @@
 import * as fc from 'fast-check';
 import { predictStealthSafeAddressWithBytecode, predictStealthSafeAddressWithClient } from '../src';
+import { InitializerExtraFields } from '../src/predictStealthSafeAddressTypes';
 
 describe('predictStealthSafeAddressWithClient', () => {
   it('should predict the correct stealth safe address', async () => {
@@ -108,6 +109,34 @@ describe('predictStealthSafeAddressWithClient', () => {
       }),
     ).rejects.toThrow('chainId is required when useDefaultAddress is false');
   }, 60000);
+
+  it('should predict correctly with initializerExtraFields set', async () => {
+    const chainId = 1;
+    const threshold = 2;
+    const stealthAddresses: `0x${string}`[] = [
+      '0xb9e7de28c2e6c8f3c29fc0e061485a34c5864614',
+      '0x5a655820821bf7af7b23566b34ce0ccbd9c9a37f',
+    ];
+    const initializerExtraFields: InitializerExtraFields = {
+      to: '0x1111111111111111111111111111111111111111',
+      data: '0xdeadbeef',
+      fallbackHandler: '0x2222222222222222222222222222222222222222',
+      paymentToken: '0x3333333333333333333333333333333333333333',
+      payment: '1000000000000000000',
+      paymentReceiver: '0x4444444444444444444444444444444444444444',
+    };
+    const expectedStealthSafeAddress = '0xe28c58e52697a8b93f7d714aeadfc3ad156c7237';
+
+    const result = await predictStealthSafeAddressWithClient({
+      chainId,
+      threshold,
+      stealthAddresses,
+      safeVersion: '1.3.0',
+      initializerExtraFields,
+    });
+
+    expect(result).toEqual({ stealthSafeAddress: expectedStealthSafeAddress });
+  });
 
 });
 
@@ -243,4 +272,33 @@ describe('predictStealthSafeAddressWithBytecode', () => {
       });
     }).toThrow('chainId is required when useDefaultAddress is false');
   });
+
+  it('should predict correctly with initializerExtraFields set', async () => {
+    const threshold = 2;
+    const stealthAddresses: `0x${string}`[] = [
+      '0xb9e7de28c2e6c8f3c29fc0e061485a34c5864614',
+      '0x5a655820821bf7af7b23566b34ce0ccbd9c9a37f',
+    ];
+    const initializerExtraFields: InitializerExtraFields = {
+      to: '0x1111111111111111111111111111111111111111',
+      data: '0xdeadbeef',
+      fallbackHandler: '0x2222222222222222222222222222222222222222',
+      paymentToken: '0x3333333333333333333333333333333333333333',
+      payment: '1000000000000000000',
+      paymentReceiver: '0x4444444444444444444444444444444444444444',
+    };
+    const expectedStealthSafeAddress = '0xe28c58e52697a8b93f7d714aeadfc3ad156c7237';
+
+    const result = predictStealthSafeAddressWithBytecode({
+      threshold,
+      stealthAddresses,
+      safeVersion: '1.3.0',
+      safeProxyBytecode,
+      useDefaultAddress: true,
+      initializerExtraFields,
+    });
+
+    expect(result).toEqual({ stealthSafeAddress: expectedStealthSafeAddress });
+  });
+
 });


### PR DESCRIPTION
This PR adds the ability to set any custom data within the Initializer field when calling the `setup` function during Safe Deployment. Among different use cases, it can enable the installation of modules during the deployment, allowing the creation of counterfactual addresses with modules already installed